### PR TITLE
fix: type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.8",
-        "@vitejs/plugin-vue": "4.5.2",
+        "@vitejs/plugin-vue": "5.0.3",
         "@vue/eslint-config-typescript": "12.0.0",
         "eslint": "8.56.0",
         "eslint-plugin-vue": "9.19.2",
@@ -1870,15 +1870,15 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
-      "integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
       "dev": true,
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^5.0.0",
+        "vite": "^5.0.0",
         "vue": "^3.2.25"
       }
     },
@@ -9057,19 +9057,6 @@
         "postcss": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
-      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
-      "dev": true,
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.0.0",
-        "vue": "^3.2.25"
       }
     },
     "node_modules/vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.8",
-        "@vitejs/plugin-vue": "5.0.3",
+        "@vitejs/plugin-vue": "4.5.2",
         "@vue/eslint-config-typescript": "12.0.0",
         "eslint": "8.56.0",
         "eslint-plugin-vue": "9.19.2",
@@ -1870,15 +1870,15 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
-      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
+      "integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
       "dev": true,
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^4.0.0 || ^5.0.0",
         "vue": "^3.2.25"
       }
     },
@@ -9057,6 +9057,19 @@
         "postcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0",
+        "vue": "^3.2.25"
       }
     },
     "node_modules/vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "time-blocks-vue",
       "version": "0.1.0",
       "dependencies": {
-        "date-fns": "^3.2.0"
+        "date-fns": "^3.0.0",
+        "vue": "^3.3.12"
       },
       "devDependencies": {
         "@types/node": "^20.10.8",
@@ -22,7 +23,6 @@
         "unplugin-vue-components": "^0.26.0",
         "vite": "^5.0.10",
         "vitepress": "^1.0.0-rc.36",
-        "vue": "^3.3.13",
         "vue-tsc": "^1.8.27"
       }
     },
@@ -400,7 +400,6 @@
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
       "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -970,8 +969,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1911,54 +1909,103 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.6.tgz",
-      "integrity": "sha512-9SmkpHsXqhHGMIOp4cawUqp0AxLN2fJJfxh3sR2RaouVx/Y/ww5ts3dfpD9SCvD0n8cdO/Xw+kWEpa6EkH/vTQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.14.tgz",
+      "integrity": "sha512-ro4Zzl/MPdWs7XwxT7omHRxAjMbDFRZEEjD+2m3NBf8YzAe3HuoSEZosXQo+m1GQ1G3LQ1LdmNh1RKTYe+ssEg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.6",
+        "@vue/shared": "3.4.14",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.6.tgz",
-      "integrity": "sha512-i39ZuyHPzPb0v5yXZbvODGwLr+T7lS1rYSjMd1oCTa14aDP80kYpWXrWPF1JVD4QJJNyLgFnJ2hxvFLM7dy9NQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.14.tgz",
+      "integrity": "sha512-nOZTY+veWNa0DKAceNWxorAbWm0INHdQq7cejFaWM1WYnoNSJbSEKYtE7Ir6lR/+mo9fttZpPVI9ZFGJ1juUEQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.6",
-        "@vue/shared": "3.4.6"
+        "@vue/compiler-core": "3.4.14",
+        "@vue/shared": "3.4.14"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.6.tgz",
-      "integrity": "sha512-kTFOiyMtuetFqi5yEPA4hR6FTD36zKKY3qaBonxGb4pgj0yK1eACqH+iycTAsEqr2u4cOhcGkx3Yjecpgh6FTQ==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.12.tgz",
+      "integrity": "sha512-yy5b9e7b79dsGbMmglCe/YnhCQgBkHO7Uf6JfjWPSf2/5XH+MKn18LhzhHyxbHdJgnA4lZCqtXzLaJz8Pd8lMw==",
       "dependencies": {
-        "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.6",
-        "@vue/compiler-dom": "3.4.6",
-        "@vue/compiler-ssr": "3.4.6",
-        "@vue/shared": "3.4.6",
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/reactivity-transform": "3.3.12",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.32",
         "source-map-js": "^1.0.2"
       }
     },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.6.tgz",
-      "integrity": "sha512-XqeojjDitjMLyOogDePNSxw9XL4FAXchO9oOfqdzLVEtYES5j+AEilPJyP0KhQPfGecY2mJ3Y7/e6kkiJQLKvg==",
-      "dev": true,
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.6",
-        "@vue/shared": "3.4.6"
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
       }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz",
+      "integrity": "sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==",
+      "dependencies": {
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.12.tgz",
+      "integrity": "sha512-adCiMJPznfWcQyk/9HSuXGja859IaMV+b8UNSVzDatqv7h0PvT9BEeS22+gjkWofDiSg5d78/ZLls3sLA+cn3A==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/shared": "3.3.12"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-core": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-dom": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz",
+      "integrity": "sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==",
+      "dependencies": {
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
     },
     "node_modules/@vue/devtools-api": {
       "version": "6.5.1",
@@ -2016,52 +2063,96 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.6.tgz",
-      "integrity": "sha512-/VuOxdWDyAeKFHjOuSKEtH9jEVPRgsXxu84utBP1SiXFcFRx2prwiC9cSR8hKOfj5nBwhLXYb6XEU69mLpuk0w==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.12.tgz",
+      "integrity": "sha512-vOJORzO8DlIx88cgTnMLIf2GlLYpoXAKsuoQsK6SGdaqODjxO129pVPTd2s/N/Mb6KKZEFIHIEwWGmtN4YPs+g==",
       "dependencies": {
-        "@vue/shared": "3.4.6"
+        "@vue/shared": "3.3.12"
       }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.12.tgz",
+      "integrity": "sha512-g5TijmML7FyKkLt6QnpqNmA4KD7K/T5SbXa88Bhq+hydNQEkzA8veVXWAQuNqg9rjaFYD0rPf0a9NofKA0ENgg==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/reactivity-transform/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
+    },
+    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.6.tgz",
-      "integrity": "sha512-XDOx8iiNmP66p+goUHT5XL1AnV8406VVFQARbylqmSCBZEtxchfu2ZoQk7U07ze8G/E0/BtX/C5o29zB1W4o5A==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.12.tgz",
+      "integrity": "sha512-5iL4w7MZrSGKEZU2wFAYhDZdZmgn+s//73EfgDXW1M+ZUOl36md7tlWp1QFK/ladiq4FvQ82shVjo0KiPDPr0A==",
       "dependencies": {
-        "@vue/reactivity": "3.4.6",
-        "@vue/shared": "3.4.6"
+        "@vue/reactivity": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
+    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.6.tgz",
-      "integrity": "sha512-8bdQR5CLfzClGvAOfbbCF8adE9oko0pRfe+dj297i0JCdCJ8AuyUMsXkt6vGPcRPqIKX4Z8f/bDPrwl+c7e4Wg==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.12.tgz",
+      "integrity": "sha512-8mMzqiIdl+IYa/OXwKwk6/4ebLq7cYV1pUcwCSwBK2KerUa6cwGosen5xrCL9f8o2DJ9TfPFwbPEvH7OXzUpoA==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.6",
-        "@vue/shared": "3.4.6",
+        "@vue/runtime-core": "3.3.12",
+        "@vue/shared": "3.3.12",
         "csstype": "^3.1.3"
       }
     },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
+    },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.6.tgz",
-      "integrity": "sha512-0LS+GXf3M93KloaK/S0ZPq5PnKERgPAV5iNCCpjyBLhAQGGEeqfJojs3yXOAMQLSvXi9FLYDHzDEOLWoLaYbTQ==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.12.tgz",
+      "integrity": "sha512-OZ0IEK5TU5GXb5J8/wSplyxvGGdIcwEmS8EIO302Vz8K6fGSgSJTU54X0Sb6PaefzZdiN3vHsLXO8XIeF8crQQ==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.6",
-        "@vue/shared": "3.4.6"
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/shared": "3.3.12"
       },
       "peerDependencies": {
-        "vue": "3.4.6"
+        "vue": "3.3.12"
       }
     },
+    "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
+    },
     "node_modules/@vue/shared": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.6.tgz",
-      "integrity": "sha512-O16vewA05D0IwfG2N/OFEuVeb17pieaI32mmYXp36V8lp+/pI1YV04rRL9Eyjndj3xQO5SNjAxTh6ul4IlBa3A==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.14.tgz",
+      "integrity": "sha512-nmi3BtLpvqXAWoRZ6HQ+pFJOHBU4UnH3vD3opgmwXac7vhaHKA9nj1VeGjMggdB9eLtW83eHyPCmOU1qzdsC7Q==",
       "dev": true
     },
     "node_modules/@vueuse/core": {
@@ -2803,13 +2894,12 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/date-fns": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
-      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.0.0.tgz",
+      "integrity": "sha512-xjDz3rNN9jp+Lh3P/4MeY4E5HkaRnEnrJCcrdRZnKdn42gJlIe6hwrrwVXePRwVR2kh1UcMnz00erYBnHF8PFA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -3231,8 +3321,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4252,7 +4341,6 @@
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
       "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -4423,7 +4511,6 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7733,8 +7820,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -7832,7 +7918,6 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8503,7 +8588,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8813,7 +8897,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9059,17 +9143,107 @@
         }
       }
     },
-    "node_modules/vue": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.6.tgz",
-      "integrity": "sha512-gAzw5oP0/h34/yq1LjLNpn4wrCKYMuWp2jbs/JirFiZAFWYhd9jTkXp4wIi5ApgMJrMgD6YFyyXwKsqFYR31IQ==",
+    "node_modules/vitepress/node_modules/@vue/compiler-sfc": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.14.tgz",
+      "integrity": "sha512-1vHc9Kv1jV+YBZC/RJxQJ9JCxildTI+qrhtDh6tPkR1O8S+olBUekimY0km0ZNn8nG1wjtFAe9XHij+YLR8cRQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.6",
-        "@vue/compiler-sfc": "3.4.6",
-        "@vue/runtime-dom": "3.4.6",
-        "@vue/server-renderer": "3.4.6",
-        "@vue/shared": "3.4.6"
+        "@babel/parser": "^7.23.6",
+        "@vue/compiler-core": "3.4.14",
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/compiler-ssr": "3.4.14",
+        "@vue/shared": "3.4.14",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.33",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/compiler-ssr": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.14.tgz",
+      "integrity": "sha512-bXT6+oAGlFjTYVOTtFJ4l4Jab1wjsC0cfSfOe2B4Z0N2vD2zOBSQ9w694RsCfhjk+bC2DY5Gubb1rHZVii107Q==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/shared": "3.4.14"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/reactivity": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.14.tgz",
+      "integrity": "sha512-xRYwze5Q4tK7tT2J4uy4XLhK/AIXdU5EBUu9PLnIHcOKXO0uyXpNNMzlQKuq7B+zwtq6K2wuUL39pHA6ZQzObw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.4.14"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/runtime-core": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.14.tgz",
+      "integrity": "sha512-qu+NMkfujCoZL6cfqK5NOfxgXJROSlP2ZPs4CTcVR+mLrwl4TtycF5Tgo0QupkdBL+2kigc6EsJlTcuuZC1NaQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.4.14",
+        "@vue/shared": "3.4.14"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/runtime-dom": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.14.tgz",
+      "integrity": "sha512-B85XmcR4E7XsirEHVqhmy4HPbRT9WLFWV9Uhie3OapV9m1MEN9+Er6hmUIE6d8/l2sUygpK9RstFM2bmHEUigA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.4.14",
+        "@vue/shared": "3.4.14",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/server-renderer": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.14.tgz",
+      "integrity": "sha512-pwSKXQfYdJBTpvWHGEYI+akDE18TXAiLcGn+Q/2Fj8wQSHWztoo7PSvfMNqu6NDhp309QXXbPFEGCU5p85HqkA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.14",
+        "@vue/shared": "3.4.14"
+      },
+      "peerDependencies": {
+        "vue": "3.4.14"
+      }
+    },
+    "node_modules/vitepress/node_modules/vue": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.14.tgz",
+      "integrity": "sha512-Rop5Al/ZcBbBz+KjPZaZDgHDX0kUP4duEzDbm+1o91uxYUNmJrZSBuegsNIJvUGy+epLevNRNhLjm08VKTgGyw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/compiler-sfc": "3.4.14",
+        "@vue/runtime-dom": "3.4.14",
+        "@vue/server-renderer": "3.4.14",
+        "@vue/shared": "3.4.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.12.tgz",
+      "integrity": "sha512-jYNv2QmET2OTHsFzfWHMnqgCfqL4zfo97QwofdET+GBRCHhSCHuMTTvNIgeSn0/xF3JRT5OGah6MDwUFN7MPlg==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-sfc": "3.3.12",
+        "@vue/runtime-dom": "3.3.12",
+        "@vue/server-renderer": "3.3.12",
+        "@vue/shared": "3.3.12"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -9155,6 +9329,31 @@
       "peerDependencies": {
         "typescript": "*"
       }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-core": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-dom": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz",
+      "integrity": "sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==",
+      "dependencies": {
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/shared": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
     },
     "node_modules/webpack-sources": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.8",
-    "@vitejs/plugin-vue": "5.0.3",
+    "@vitejs/plugin-vue": "4.5.2",
     "@vue/eslint-config-typescript": "12.0.0",
     "eslint": "8.56.0",
     "sass": "^1.69.5",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --declaration --emitDeclarationOnly && vite build",
-    "types": "vue-tsc ",
+    "types": "vue-tsc",
     "preview": "vite preview",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:serve": "vitepress serve docs"
   },
   "dependencies": {
-    "date-fns": "^3.2.0"
+    "date-fns": "^3.0.0",
+    "vue": "^3.3.12"
   },
   "devDependencies": {
     "@types/node": "^20.10.8",
@@ -39,7 +40,6 @@
     "unplugin-vue-components": "^0.26.0",
     "vite": "^5.0.10",
     "vitepress": "^1.0.0-rc.36",
-    "vue": "^3.3.13",
     "vue-tsc": "^1.8.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && vue-tsc --declaration --emitDeclarationOnly",
+    "build": "vue-tsc --declaration --emitDeclarationOnly && vite build",
     "types": "vue-tsc ",
     "preview": "vite preview",
     "docs:dev": "vitepress dev docs",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.8",
-    "@vitejs/plugin-vue": "4.5.2",
+    "@vitejs/plugin-vue": "5.0.3",
     "@vue/eslint-config-typescript": "12.0.0",
     "eslint": "8.56.0",
     "sass": "^1.69.5",


### PR DESCRIPTION
Something to do with a newer vue version was causing component type declaration to use `import("vue").PublicProps` instead `import("vue").VNodeProps`. This resulted in type `any` when importing `EventCalendar` into a project.