### PR TITLE
fix: lower date-fns dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "time-blocks-vue",
       "version": "0.1.0",
       "dependencies": {
-        "date-fns": "^3.0.0",
+        "date-fns": "^2.28.0 || ^3.0.0",
         "vue": "^3.3.12"
       },
       "devDependencies": {
@@ -2897,12 +2897,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/date-fns": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.0.0.tgz",
-      "integrity": "sha512-xjDz3rNN9jp+Lh3P/4MeY4E5HkaRnEnrJCcrdRZnKdn42gJlIe6hwrrwVXePRwVR2kh1UcMnz00erYBnHF8PFA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/de-indent": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:serve": "vitepress serve docs"
   },
   "dependencies": {
-    "date-fns": "^3.0.0",
+    "date-fns": "^2.28.0 || ^3.0.0",
     "vue": "^3.3.12"
   },
   "devDependencies": {

--- a/src/helpers/DateHelper.ts
+++ b/src/helpers/DateHelper.ts
@@ -1,35 +1,7 @@
 import { addDays, startOfWeek, isWeekend, Day } from "date-fns";
 
-export function getWeekRange(
-  date: Date | string,
-  startDayOfWeek: number = 0
-): { start: Date; end: Date } {
-  if (typeof date == typeof "string") {
-    date = new Date(date + "T00:00:00");
-  }
-  const startDate = new Date(date);
-  const endDate = new Date(date);
-  // Calculate the difference from the start day of the week
-  let dayDifference = startDate.getDay() - startDayOfWeek;
-
-  // Correct the day difference if the day is before the start day of the week
-  if (dayDifference < 0) {
-    dayDifference += 7;
-  }
-
-  // Adjust the start and end dates
-  startDate.setDate(startDate.getDate() - dayDifference);
-  endDate.setDate(startDate.getDate() + 6);
-
-  // Ensure start and end dates are at the beginning and end of their respective days
-  startDate.setHours(0, 0, 0, 0); // Set to start of the day
-  endDate.setHours(23, 59, 59, 999); // Set to end of the day
-
-  return { start: startDate, end: endDate };
-}
-
 export function getWeekDays(
-  date: Date | string,
+  date: Date,
   includeWeekends: boolean = true,
   startDayOfWeek: Day = 0
 ): Date[] {
@@ -46,13 +18,4 @@ export function getWeekDays(
   }
 
   return weekDays;
-}
-
-export function mergeTime(date: Date, time: Date) {
-  const newDate = new Date(date);
-  newDate.setHours(time.getHours());
-  newDate.setMinutes(time.getMinutes());
-  newDate.setSeconds(time.getSeconds());
-  newDate.setMilliseconds(time.getMilliseconds());
-  return newDate;
 }


### PR DESCRIPTION
fixes: #47 
- adjusted date-fns dependency to `"^2.28.0 || ^3.0.0"` from `"^3.0.0"` to accomodate date-fns-tz
- adjusted helper function to reflect version compatibility changes
- removed old un-used helper functions