### PR TITLE
feat: add tooltip

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -1,18 +1,34 @@
 <template>
   <div>
-    <button @click="showWeekends = !showWeekends">asdf</button>
+    <button @click="showWeekends = !showWeekends">
+      weekends: {{ !showWeekends }}
+    </button>
+    <button @click="darkMode = !darkMode">dark: {{ darkMode }}</button>
     <div :style="{ width: '100%', height: '80vh' }">
       <EventCalendar
         :events="events"
         :hide-weekends="showWeekends"
         :interval-height="intervalHeight"
         :interval-minutes="intervalMinutes"
+        :dark-mode="darkMode"
         @event-created="onEventCreation"
         @event-clicked="(e) => console.log(e)"
         :concurrency-mode="'stack'"
         :default-event-properties="{ color: 'grey' }"
       >
-        <template #calendarEvent="{ event }">
+        <!-- <template #eventTooltip="{ event }">
+          <div
+            style="
+              border: 1px solid white;
+              background-color: lime;
+              padding: 1rem;
+              width: 100px;
+            "
+          >
+            test
+          </div>
+        </template> -->
+        <!-- <template #calendarEvent="{ event }">
           <div
             class="material-card"
             :style="{
@@ -30,7 +46,7 @@
               {{ event.description }}
             </div>
           </div>
-        </template>
+        </template> -->
 
         <!-- <template #dayHeader="{ date, totalTime }">
           <div
@@ -65,11 +81,11 @@ import EventCalendar from "../src/components/EventCalendar.vue";
 import { CalendarEvent } from "../src/types/interfaces";
 import { addMinutes, startOfWeek } from "date-fns";
 import { randomColor, guid } from "../src/helpers/Utility";
-import { format } from "date-fns";
 
 const intervalMinutes = ref(15);
 const intervalHeight = ref(20);
 const showWeekends = ref(false);
+const darkMode = ref(false);
 const events = ref<CalendarEvent[]>(
   Array.from({ length: 24 }, () => {
     const startDate = addMinutes(

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -34,7 +34,14 @@
       @event-clicked="emits('event-clicked', event)"
     >
       <template #event="{ event }">
-        <slot :event="event"> </slot>
+        <slot :event="event" />
+      </template>
+
+      <template #eventTooltip="{ event }">
+        <slot name="eventTooltip" :event="event" />
+      </template>
+      <template #eventTooltipContent="{ event }">
+        <slot name="eventTooltipContent" :event="event" />
       </template>
     </DayEvent>
   </div>

--- a/src/components/DayEvent.vue
+++ b/src/components/DayEvent.vue
@@ -11,8 +11,10 @@
       zIndex: zIndex,
     }"
     @mousedown.stop.left="onMouseDown('body')"
-    @mouseover="hovering = true"
-    @mouseleave="hovering = false"
+    @mousemove="onMouseMove"
+    @mouseover="onMouseEnter"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
     @click.stop.left="emits('event-clicked', event)"
   >
     <div
@@ -40,7 +42,7 @@
               height: '100%',
             }"
           ></div>
-          <div>
+          <div style="padding: 0.25rem">
             {{ format(event.startDate, "hh:mm a") }}
             -
             {{ format(event.endDate, "hh:mm a") }}
@@ -75,17 +77,60 @@
       "
       @mousedown.stop.left="onMouseDown('bottom')"
     />
+
+    <div
+      :style="{
+        position: 'fixed',
+        top: `${tooltipLocation.y}px`,
+        left: `${tooltipLocation.x}px`,
+        transform: `translateX(-${tooltipOffset}px)`,
+        visibility: showTooltip ? 'visible' : 'hidden',
+      }"
+      ref="tooltip"
+    >
+      <slot name="eventTooltip" :event="event">
+        <div class="tooltip">
+          <slot name="eventTooltipContent" :event="event">
+            <div class="tooltip-content">
+              {{ format(event.startDate, "E M/d") }}
+              <br />
+              {{ format(event.startDate, "hh:mm a") }}
+              -
+              {{ format(event.endDate, "hh:mm a") }}
+              <br />
+              {{ event.description }}
+            </div>
+          </slot>
+        </div>
+      </slot>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { format, differenceInMinutes } from "date-fns";
 import { $CalendarEvent } from "../types/interfaces";
-import { computed, ref, watch } from "vue";
+import {
+  computed,
+  reactive,
+  ref,
+  watch,
+  inject,
+  Ref,
+  onMounted,
+  onUnmounted,
+} from "vue";
+
+const calendarDiv = inject("CalendarDiv") as Ref<HTMLDivElement | null>;
+const tooltip = ref<HTMLDivElement | null>(null);
 
 const hovering = ref(false);
 const bringToFront = ref(false);
-let interval: NodeJS.Timeout;
+const showTooltip = ref(false);
+const tooltipLocation = reactive({ x: 0, y: 0 });
+const lastMouseLocation: { x: number; y: number } = { x: 0, y: 0 };
+
+let tooltipTimeout: NodeJS.Timeout;
 
 const emits = defineEmits<{
   (e: "event-mousedown", handle: "top" | "bottom" | "body"): void;
@@ -102,13 +147,22 @@ const props = defineProps<{
 
 watch(hovering, (v) => {
   if (v) {
-    interval = setInterval(() => {
+    setTimeout(() => {
+      if (!hovering.value) return;
       bringToFront.value = true;
     }, 650);
   } else {
     bringToFront.value = false;
-    clearInterval(interval);
+    showTooltip.value = false;
   }
+});
+
+onMounted(() => {
+  addEventListener("wheel", onMouseWheel);
+});
+
+onUnmounted(() => {
+  removeEventListener("wheel", onMouseWheel);
 });
 
 const zIndex = computed(() => (bringToFront.value ? 99 : props.event.zIndex));
@@ -150,7 +204,25 @@ const width = computed(() => {
   }
 });
 
+function onMouseEnter(e: MouseEvent) {
+  lastMouseLocation.x = e.clientX;
+  lastMouseLocation.y = e.clientY;
+  hovering.value = true;
+}
+
+function onMouseLeave() {
+  hovering.value = false;
+  showTooltip.value = false;
+}
+
+function onMouseMove(e: MouseEvent) {
+  lastMouseLocation.x = e.clientX;
+  lastMouseLocation.y = e.clientY;
+  restartTooltip();
+}
+
 function onMouseDown(handle: "top" | "bottom" | "body") {
+  showTooltip.value = false;
   document.addEventListener("mouseup", onMouseUp);
   emits("event-mousedown", handle);
 }
@@ -159,30 +231,84 @@ function onMouseUp() {
   document.removeEventListener("mouseup", onMouseUp);
   emits("event-mouseup");
 }
+
+function onMouseWheel() {
+  restartTooltip();
+}
+
+function restartTooltip() {
+  showTooltip.value = false;
+
+  clearTimeout(tooltipTimeout);
+  tooltipTimeout = setTimeout(() => {
+    if (!hovering.value) {
+      showTooltip.value = false;
+      return;
+    }
+
+    showTooltip.value = true;
+    tooltipLocation.x = lastMouseLocation.x + 16;
+    tooltipLocation.y = lastMouseLocation.y + 16;
+
+    // contain tooltip within the bounds of the calendar
+    if (tooltip.value && calendarDiv.value) {
+      const { width, height } = tooltip.value.getBoundingClientRect();
+      const { right: calendarRight, bottom: calendarBottom } =
+        calendarDiv.value.getBoundingClientRect();
+
+      const tooltipRight = tooltipLocation.x + width;
+      const tooltipBottom = tooltipLocation.y + height;
+
+      if (tooltipRight > calendarRight) {
+        tooltipLocation.x -= tooltipRight - calendarRight;
+      }
+
+      if (tooltipBottom > calendarBottom) {
+        tooltipLocation.y -= tooltipBottom - calendarBottom;
+      }
+    }
+  }, 750);
+}
+
+const tooltipOffset = ref(0);
 </script>
 
 <style scoped lang="scss">
 .event-card {
-  width: 100%;
-  height: 100%;
   background-color: white;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.1);
   transition: box-shadow 0.3s ease-in-out;
-  overflow: hidden;
+}
+
+.event-card * {
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  font-size: 14px;
 }
 
 .event-card:hover {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15), 0 8px 16px rgba(0, 0, 0, 0.15);
 }
-</style>
-
-<style>
 .event-card-root > * {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
   overflow: hidden;
+  position: relative;
+}
+
+.tooltip {
+  background-color: #3f3f3f;
+  border-radius: 2px;
+  border: 1px solid white;
+  color: white;
+}
+
+.tooltip-content {
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  font-size: 14px;
+  width: 200px;
+  margin: 4px;
 }
 </style>
 ../types/interfaces.ts

--- a/src/components/Week.vue
+++ b/src/components/Week.vue
@@ -165,8 +165,17 @@
           <template #default="{ event }">
             <slot name="calendarEvent" :event="event" />
           </template>
+
           <template #nowIndicator>
             <slot name="nowIndicator" />
+          </template>
+
+          <template #eventTooltip="{ event }">
+            <slot name="eventTooltip" :event="event" />
+          </template>
+
+          <template #eventTooltipContent="{ event }">
+            <slot name="eventTooltipContent" :event="event" />
           </template>
         </Day>
       </div>
@@ -216,7 +225,7 @@ let activeEvent: $CalendarEvent | null = null;
 let activeHandle: "top" | "bottom" | "body" | null = null;
 let creatingEvent = false;
 
-const rootDiv = ref();
+const rootDiv = ref<HTMLElement | null>(null);
 const scrollDiv = ref();
 const newEvent = ref<$CalendarEvent | null>(null);
 const mousePosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });


### PR DESCRIPTION
fixes: #52 - Tooltip for event cards
- A tooltip will pop up when cursor hovers over event cards, displaying date, start/end times, and description.
- Added slot to override tooltip content
- Added slot for custom tooltips
