### PR TITLE
feat: add readonly property to calendar events

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -110,6 +110,7 @@ const events = ref<CalendarEvent[]>(
       endDate,
       description: randomText(),
       color: randomColor(),
+      readonly: true,
     };
   })
 );

--- a/src/components/DayEvent.vue
+++ b/src/components/DayEvent.vue
@@ -54,6 +54,7 @@
     </div>
 
     <div
+      v-if="!event.readonly"
       style="
         top: 0px;
         position: absolute;
@@ -66,6 +67,7 @@
       @mousedown.stop="onMouseDown('top')"
     />
     <div
+      v-if="!event.readonly"
       style="
         bottom: 0px;
         position: absolute;
@@ -232,6 +234,9 @@ function onMouseMove(e: MouseEvent) {
 
 function onMouseDown(handle: "top" | "bottom" | "body") {
   showTooltip.value = false;
+  if (props.event.readonly === true) {
+    return;
+  }
   document.addEventListener("mouseup", onMouseUp);
   emits("event-mousedown", handle);
 }

--- a/src/components/Week.vue
+++ b/src/components/Week.vue
@@ -261,6 +261,7 @@ const mouseDay = computed(() => {
 });
 
 function onMouseDown(event: $CalendarEvent, handle: "top" | "bottom" | "body") {
+  if (event.readonly === true) return;
   activeEvent = event;
   startY = mousePosition.value.y;
   initialState = { ...event };
@@ -275,8 +276,8 @@ function onMouseUp() {
 
   if (activeEvent && !creatingEvent) {
     if (
-      activeEvent.startDate != initialState?.startDate ||
-      activeEvent.endDate != initialState?.endDate
+      activeEvent.startDate.getTime() != initialState?.startDate.getTime() ||
+      activeEvent.endDate.getTime() != initialState?.endDate.getTime()
     ) {
       emits("event-updated", activeEvent);
     }
@@ -285,6 +286,7 @@ function onMouseUp() {
   isDragging = false;
   creatingEvent = false;
   newEvent.value = null;
+  activeEvent = null;
 }
 
 function onMouseMove(event: MouseEvent) {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -4,6 +4,7 @@ export interface CalendarEvent {
   startDate: Date;
   endDate: Date;
   color?: string;
+  readonly?: boolean;
 }
 
 export interface $CalendarEvent extends CalendarEvent {


### PR DESCRIPTION
- also fixes an issue where firing the updated event was comparing date object references rather than their time.