### PR TITLE
feat: add context menu event

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -13,6 +13,7 @@
         :dark-mode="darkMode"
         @event-created="onEventCreation"
         @event-clicked="(e) => console.log(e)"
+        @event-contextmenu="(e) => console.log(e)"
         :concurrency-mode="'stack'"
         :default-event-properties="{ color: 'grey' }"
       >

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -85,11 +85,12 @@ The color property will have no affect when implementing a custom [CalendarEvent
 :::
 
 ## Events
-| Event Name    | Payload       | Purpose                                    |
-| ------------- | ------------- | ------------------------------------------ |
-| event-created | CalendarEvent | Emitted when a new event is created.       |
-| event-clicked | CalendarEvent | Emitted when an event is clicked.          |
-| event-updated | CalendarEvent | Emitted when an existing event is updated. |
+| Event Name        | Payload       | Purpose                                          |
+| ----------------- | ------------- | ------------------------------------------------ |
+| event-created     | CalendarEvent | Emitted when a new event is created.             |
+| event-clicked     | CalendarEvent | Emitted when an event is clicked.                |
+| event-updated     | CalendarEvent | Emitted when an existing event is updated.       |
+| event-contextmenu | CalendarEvent | Emitted when an existing event is right clicked. |
 
 ::: info
 Event calendar will allow the user to draw out a new event that is populated with a unique id, and the appropriate start and end dates. However it does nothing with this info other than emit the `event-created` event, this is where you would want to process what should actually happen.

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -32,6 +32,7 @@
       @event-mousedown="(h: 'top' | 'bottom' | 'body') => emits('event-mousedown', event, h)"
       @event-mouseup="emits('event-mouseup')"
       @event-clicked="emits('event-clicked', event)"
+      @event-contextmenu="emits('event-contextmenu', event)"
     >
       <template #event="{ event }">
         <slot :event="event" />
@@ -103,6 +104,7 @@ const emits = defineEmits<{
   ): void;
   (e: "event-mouseup"): void;
   (e: "event-clicked", event: $CalendarEvent): void;
+  (e: "event-contextmenu", event: $CalendarEvent): void;
 }>();
 </script>
 

--- a/src/components/DayEvent.vue
+++ b/src/components/DayEvent.vue
@@ -16,6 +16,7 @@
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
     @click.stop.left="emits('event-clicked', event)"
+    @click.prevent.right="emits('event-contextmenu', event)"
   >
     <div
       :style="{
@@ -150,6 +151,7 @@ const emits = defineEmits<{
   (e: "event-mousedown", handle: "top" | "bottom" | "body"): void;
   (e: "event-mouseup"): void;
   (e: "event-clicked", event: $CalendarEvent): void;
+  (e: "event-contextmenu", event: $CalendarEvent): void;
 }>();
 
 const props = defineProps<{

--- a/src/components/EventCalendar.vue
+++ b/src/components/EventCalendar.vue
@@ -33,6 +33,7 @@
       @event-created="emit('event-created', $event)"
       @event-clicked="emit('event-clicked', $event)"
       @event-updated="emit('event-updated', $event)"
+      @event-contextmenu="emit('event-contextmenu', $event)"
     >
       <template #calendarEvent="{ event }">
         <slot name="calendarEvent" :event="(event as CalendarEvent)" />
@@ -98,9 +99,10 @@ provide("CalendarConfig", config);
 const emit = defineEmits<{
   (e: "event-created", event: CalendarEvent): void;
   (e: "event-clicked", event: CalendarEvent): void;
+  (e: "event-updated", event: CalendarEvent): void;
+  (e: "event-contextmenu", event: CalendarEvent): void;
   (e: "update:date", date: Date): void;
   (e: "update:mode", mode: "week" | "day"): void;
-  (e: "event-updated", event: CalendarEvent): void;
 }>();
 
 const props = withDefaults(

--- a/src/components/Week.vue
+++ b/src/components/Week.vue
@@ -161,6 +161,7 @@
           :concurrency-mode="concurrencyMode"
           @event-mousedown="onMouseDown"
           @event-clicked="onEventClicked"
+          @event-contextmenu="emits('event-contextmenu', $event)"
         >
           <template #default="{ event }">
             <slot name="calendarEvent" :event="event" />
@@ -202,6 +203,7 @@ const emits = defineEmits<{
   (e: "event-created", event: CalendarEvent): void;
   (e: "event-clicked", event: CalendarEvent): void;
   (e: "event-updated", event: CalendarEvent): void;
+  (e: "event-contextmenu", event: $CalendarEvent): void;
 }>();
 
 const props = defineProps<{


### PR DESCRIPTION
Adds an event '@event-contextmenu' for when a user right clicks on an existing event.

https://github.com/vicdotexe/time-blocks-vue/assets/84735487/65100d4d-5ba5-4f2c-b7ab-5a96377092c7

