### PR TITLE
fix: make now indicator always render on the correct day

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -86,7 +86,7 @@ onUnmounted(() => {
   clearInterval(interval);
 });
 
-const isDateToday = computed(() => isToday(props.date));
+const isDateToday = computed(() => isSameDay(now.value, props.date));
 
 const filteredEvents = computed(() => {
   let filtered = props.events.filter((e) => isSameDay(e.startDate, props.date));


### PR DESCRIPTION
`isDateToday` was not reactive to changes in the current date.